### PR TITLE
Allowing alphanumerical SMS SenderIDs

### DIFF
--- a/src/main/kotlin/net/folivo/matrix/bridge/sms/provider/gammu/GammuSmsProvider.kt
+++ b/src/main/kotlin/net/folivo/matrix/bridge/sms/provider/gammu/GammuSmsProvider.kt
@@ -122,13 +122,30 @@ class GammuSmsProvider(
 
     }
 
+    fun isDigits(chars: String): Boolean {
+        return chars.matches("""^\+*[0-9]*$""".toRegex())
+    }
+
     fun receiveSms(
         sender: String,
         body: String
     ): Mono<Void> {
         return mono {
-            val phoneNumber = phoneNumberService.parseToInternationalNumber(sender)
-            receiveSmsService.receiveSms(body = body, sender = phoneNumber)
+	    var phoneNumber = phoneNumberService.parseToInternationalNumber(properties.alphaFakeNumber)
+	    var messageBody = body
+	    if (properties.alphaSender == true) {
+		if (isDigits(sender)) {
+	           phoneNumber = phoneNumberService.parseToInternationalNumber(sender)
+		   }
+		else {
+		   messageBody = sender+ ":\n\n" + messageBody
+		}
+
+	}
+	    if (properties.alphaSender == false) {
+	           phoneNumber = phoneNumberService.parseToInternationalNumber(sender)
+	}
+            receiveSmsService.receiveSms(body = messageBody, sender = phoneNumber)
                 ?.also { sendSms(receiver = phoneNumber, body = it) }
         }.then()
     }

--- a/src/main/kotlin/net/folivo/matrix/bridge/sms/provider/gammu/GammuSmsProviderProperties.kt
+++ b/src/main/kotlin/net/folivo/matrix/bridge/sms/provider/gammu/GammuSmsProviderProperties.kt
@@ -7,6 +7,8 @@ import org.springframework.boot.context.properties.ConstructorBinding
 @ConstructorBinding
 data class GammuSmsProviderProperties(
     val enabled: Boolean = false,
+    val alphaSender: Boolean = false,
+    val alphaFakeNumber: String = "+491760000443",
     val inboxPath: String = "/data/spool/inbox",
     val inboxProcessedPath: String = "/data/spool/inbox_processed"
 )


### PR DESCRIPTION
Alphanumerical SMS SenderIDs are widely used by automated SMS services (2-factor auth, online banking, cc information) for one-way communication. As gammu uses the senderID as the number in the filename, the matrix-sms-bridge fails to verify the phone number. This quick hack of the gammu provider enables processing of the files and uses a configurable fake number for those messages. 
All messages from alphanumerical SenderIDs will hence be send into the same matrix room (with the configured fake number). The behaviour can be controlled via the config properties alphaSender (boolean) and alphaFakeNumber (string).
