### PR TITLE
Adding multi-bridge capabilities

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ repositories {
 }
 
 group = "net.folivo"
-version = "0.5.7"
+version = "0.5.8"
 java.sourceCompatibility = JavaVersion.VERSION_11
 
 tasks.withType<org.springframework.boot.gradle.tasks.bundling.BootJar>() {

--- a/src/main/kotlin/net/folivo/matrix/bridge/sms/SmsBridgeProperties.kt
+++ b/src/main/kotlin/net/folivo/matrix/bridge/sms/SmsBridgeProperties.kt
@@ -12,6 +12,7 @@ data class SmsBridgeProperties(
     val allowMappingWithoutToken: Boolean = true,
     val singleModeEnabled: Boolean = false,
     val defaultRegion: String,
+    val defaultLocalPart: String = "sms_",
     val defaultTimeZone: String = "UTC"
 ) {
     data class SmsBridgeTemplateProperties(

--- a/src/main/kotlin/net/folivo/matrix/bridge/sms/appservice/SmsMatrixAppserviceUserService.kt
+++ b/src/main/kotlin/net/folivo/matrix/bridge/sms/appservice/SmsMatrixAppserviceUserService.kt
@@ -3,6 +3,7 @@ package net.folivo.matrix.bridge.sms.appservice
 import net.folivo.matrix.appservice.api.user.RegisterUserParameter
 import net.folivo.matrix.bot.appservice.DefaultAppserviceUserService
 import net.folivo.matrix.bot.config.MatrixBotProperties
+import net.folivo.matrix.bridge.sms.SmsBridgeProperties
 import net.folivo.matrix.bot.user.MatrixUserService
 import net.folivo.matrix.bot.util.BotServiceHelper
 import net.folivo.matrix.core.model.MatrixId.UserId
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Service
 class SmsMatrixAppserviceUserService(
     userService: MatrixUserService,
     helper: BotServiceHelper,
+    private val smsBridgeProperties: SmsBridgeProperties,
     private val botProperties: MatrixBotProperties
 ) : DefaultAppserviceUserService(userService, helper, botProperties) {
 
@@ -19,7 +21,8 @@ class SmsMatrixAppserviceUserService(
         return if (userId == botProperties.botUserId) {
             RegisterUserParameter("SMS Bot")
         } else {
-            val telephoneNumber = userId.localpart.removePrefix("sms_")
+            val localPart = smsBridgeProperties.defaultLocalPart
+            val telephoneNumber = userId.localpart.removePrefix(localPart)
             val displayName = "+$telephoneNumber (SMS)"
             RegisterUserParameter(displayName)
         }

--- a/src/main/kotlin/net/folivo/matrix/bridge/sms/handler/MessageToSmsHandler.kt
+++ b/src/main/kotlin/net/folivo/matrix/bridge/sms/handler/MessageToSmsHandler.kt
@@ -38,7 +38,7 @@ class MessageToSmsHandler(
     ) {
         userService.getUsersByRoom(roomId)
             .filter { it.isManaged && it.id != senderId && it.id != botProperties.botUserId }
-            .map { "+" + it.id.localpart.removePrefix("sms_") to it.id }
+            .map { "+" + it.id.localpart.removePrefix(smsBridgeProperties.defaultLocalPart) to it.id }
             .collect { (receiverNumber, receiverId) ->
                 if (isTextMessage) {
                     LOG.debug("send SMS from $roomId to $receiverNumber")

--- a/src/main/kotlin/net/folivo/matrix/bridge/sms/handler/ReceiveSmsService.kt
+++ b/src/main/kotlin/net/folivo/matrix/bridge/sms/handler/ReceiveSmsService.kt
@@ -46,7 +46,7 @@ class ReceiveSmsService(
                 return null
             }
 
-            val userIdLocalpart = "sms_${sender.removePrefix("+")}"
+            val userIdLocalpart = "${smsBridgeProperties.defaultLocalPart}${sender.removePrefix("+")}"
             val userId = UserId(userIdLocalpart, matrixBotProperties.serverName)
 
             val mappingTokenMatch = Regex("#[0-9]{1,9}").find(body)

--- a/src/main/kotlin/net/folivo/matrix/bridge/sms/handler/SmsSendCommandHandler.kt
+++ b/src/main/kotlin/net/folivo/matrix/bridge/sms/handler/SmsSendCommandHandler.kt
@@ -57,7 +57,7 @@ class SmsSendCommandHandler(
     ): String {
         LOG.debug("handle command")
         val requiredManagedReceiverIds = receiverNumbers.map {
-            UserId("sms_${it.removePrefix("+")}", botProperties.serverName)
+            UserId("${smsBridgeProperties.defaultLocalPart}${it.removePrefix("+")}", botProperties.serverName)
         }.toSet()
         val membersWithoutBot = setOf(senderId, *requiredManagedReceiverIds.toTypedArray())
         val rooms = roomService.getRoomsByMembers(membersWithoutBot)

--- a/src/main/kotlin/net/folivo/matrix/bridge/sms/provider/gammu/GammuSmsProvider.kt
+++ b/src/main/kotlin/net/folivo/matrix/bridge/sms/provider/gammu/GammuSmsProvider.kt
@@ -82,6 +82,8 @@ class GammuSmsProvider(
             ProcessBuilder(
                 listOf(
                     "gammu-smsd-inject",
+		    "-c",
+		    properties.configFile,
                     "TEXT",
                     receiver,
                     "-len",

--- a/src/main/kotlin/net/folivo/matrix/bridge/sms/provider/gammu/GammuSmsProviderProperties.kt
+++ b/src/main/kotlin/net/folivo/matrix/bridge/sms/provider/gammu/GammuSmsProviderProperties.kt
@@ -8,5 +8,6 @@ import org.springframework.boot.context.properties.ConstructorBinding
 data class GammuSmsProviderProperties(
     val enabled: Boolean = false,
     val inboxPath: String = "/data/spool/inbox",
-    val inboxProcessedPath: String = "/data/spool/inbox_processed"
+    val inboxProcessedPath: String = "/data/spool/inbox_processed",
+    val configFile: String = "/etc/gammu/gammu-smsdrc-modem1"
 )


### PR DESCRIPTION
As discussed last year (sorry for completely forgetting about it) I ran into trouble when trying to run multiple bridges with a gammu setup. Adding the gammurc config option mitigated this, but the bridge also had a hardcoded prefix of 'sms_' which prevented the correct reception of incoming messages on the bridge. Last year I just changed the hardcoded prefix in my build. Today when setting up bridge number 3 I ran into the same issue, so I made the prefix configurable. 